### PR TITLE
Drawing lock, multi-pane support & error resilience

### DIFF
--- a/src/interaction/interaction-manager.ts
+++ b/src/interaction/interaction-manager.ts
@@ -65,6 +65,9 @@ export class InteractionManager<HorzScaleItem> {
 	private _isDrag: boolean = false;
 	private _isShiftKeyDown: boolean = false;
 
+	// Lock State — when true, all mouse interactions are suppressed
+	private _locked: boolean = false;
+
 	/**
 	 * Initializes the Interaction Manager, setting up all internal references and subscribing
 	 * to necessary DOM and Lightweight Charts events.
@@ -145,6 +148,25 @@ export class InteractionManager<HorzScaleItem> {
 		this._currentToolCreating = tool;
 
 		//console.log(`[InteractionManager] Set _currentToolCreating to ${tool?.id() || 'null'}`);
+	}
+
+	/**
+	 * Sets the global lock state for all drawing interactions.
+	 *
+	 * When locked, all mouse interactions (creation, selection, editing, dragging,
+	 * hovering) are suppressed. Tools remain visible but cannot be interacted with.
+	 *
+	 * @param locked - `true` to lock all interactions, `false` to unlock.
+	 */
+	public setLocked(locked: boolean): void {
+		this._locked = locked;
+	}
+
+	/**
+	 * Returns the current lock state.
+	 */
+	public isLocked(): boolean {
+		return this._locked;
 	}
 
 	/**
@@ -313,6 +335,7 @@ export class InteractionManager<HorzScaleItem> {
 	 * @private
 	 */
 	private _handleMouseDown(event: MouseEvent): void {
+		if (this._locked) { return; }
 		const point = this._eventToPoint(event);
 		if (!point) { return; }
 
@@ -432,6 +455,7 @@ export class InteractionManager<HorzScaleItem> {
 	 * @private
 	 */
 	private _handleMouseMove(event: MouseEvent): void {
+		if (this._locked) { return; }
 		const point = this._eventToPoint(event);
 		if (!point) { return; }
 
@@ -669,6 +693,7 @@ export class InteractionManager<HorzScaleItem> {
 	 * @private
 	 */
 	private _handleMouseUp(event: MouseEvent): void {
+		if (this._locked) { return; }
 
 		const point = this._eventToPoint(event);
 
@@ -1083,6 +1108,7 @@ export class InteractionManager<HorzScaleItem> {
 	 * @private
 	 */
 	private _handleDblClick(params: MouseEventParams<HorzScaleItem>): void {
+		if (this._locked) { return; }
 		const point = params.point ? new Point(params.point.x, params.point.y) : null;
 		if (!point) return;
 
@@ -1130,6 +1156,7 @@ export class InteractionManager<HorzScaleItem> {
 	 * @private
 	 */
 	private _handleCrosshairMove(params: MouseEventParams<HorzScaleItem>): void {
+		if (this._locked) { return; }
 		// --- Ghosting Logic ---
 		const toolBeingCreated = this._currentToolCreating;
 		if (toolBeingCreated) {

--- a/src/interaction/interaction-manager.ts
+++ b/src/interaction/interaction-manager.ts
@@ -111,9 +111,20 @@ export class InteractionManager<HorzScaleItem> {
 	 * // Used by LineToolsCorePlugin to position the crosshair
 	 * const logicalPoint = manager.screenPointToLineToolPoint(new Point(x, y));
 	 */
-	public screenPointToLineToolPoint(screenPoint: Point): LineToolPoint | null {
+	/**
+	 * @param screenPoint - Coordinate point to convert.
+	 * @param paneRelative - If true, screenPoint.y is already relative to the active
+	 *   pane (e.g. from LWC crosshair events). If false (default), screenPoint.y is
+	 *   relative to the chart element and needs pane-offset adjustment.
+	 */
+	public screenPointToLineToolPoint(screenPoint: Point, paneRelative: boolean = false): LineToolPoint | null {
 		const timeScale = this._chart.timeScale();
-		const price = this._series.coordinateToPrice(screenPoint.y as Coordinate);
+
+		// coordinateToPrice() expects Y relative to the pane the series is in.
+		// DOM events (_eventToPoint) give chart-element-relative Y → subtract offset.
+		// LWC crosshair events give pane-relative Y → use directly.
+		const paneRelativeY = paneRelative ? screenPoint.y : (screenPoint.y - this._getActivePaneYOffset());
+		const price = this._series.coordinateToPrice(paneRelativeY as Coordinate);
 
 		const logical = timeScale.coordinateToLogical(screenPoint.x as Coordinate);
 	 
@@ -146,8 +157,6 @@ export class InteractionManager<HorzScaleItem> {
 	 */
 	public setCurrentToolCreating(tool: BaseLineTool<HorzScaleItem> | null): void {
 		this._currentToolCreating = tool;
-
-		//console.log(`[InteractionManager] Set _currentToolCreating to ${tool?.id() || 'null'}`);
 	}
 
 	/**
@@ -189,10 +198,12 @@ export class InteractionManager<HorzScaleItem> {
 	 */
 	private _subscribeToChartEvents(): void {
 		const chartElement = this._chart.chartElement();
-		
+
 		// 1. Raw DOM Events for Drag/Click Detection and Editing
-		chartElement.addEventListener('mousedown', this._handleMouseDown.bind(this));
-		chartElement.addEventListener('mousemove', this._handleMouseMove.bind(this));
+		// Use capturing phase on chartElement so we intercept events from ALL panes
+		// (including indicator panes whose internal widgets may stop propagation)
+		chartElement.addEventListener('mousedown', this._handleMouseDown.bind(this), true);
+		chartElement.addEventListener('mousemove', this._handleMouseMove.bind(this), true);
 		window.addEventListener('mouseup', this._handleMouseUp.bind(this)); 
 		
 		// 2. LWC API Events for Ghosting/Hover/DBLClick
@@ -343,7 +354,7 @@ export class InteractionManager<HorzScaleItem> {
 		this._isDrag = false;
 		this._mouseDownPoint = point;
 		this._mouseDownTime = performance.now();
-		
+
 		// --- 1. Tool Creation START/CONTINUATION ---
 		if (this._currentToolCreating) {
 			this._creationTool = this._currentToolCreating; // The tool instance must exist here
@@ -855,7 +866,6 @@ export class InteractionManager<HorzScaleItem> {
                 // --- START SYNCHRONOUS LOGICAL SNAP FIX ---
 				// 1. Convert the (potentially) constrained screen point into a logical point
 				let finalLogicalPoint: LineToolPoint | null = this.screenPointToLineToolPoint(finalScreenPoint);
-				console.log('finalLogicalPoint after let', JSON.parse(JSON.stringify(finalLogicalPoint)))
 
                 // Check if we are placing P1 (point index 1) which is where the constraint applies
                 const isP1Click = tool.getPermanentPointsCount() === 1; 
@@ -897,7 +907,6 @@ export class InteractionManager<HorzScaleItem> {
 				//GOTCHA i suspect that since the ghost creation of a tool for point1 (then 2nd point) actually modifies _points.
 				//meaning the ghost does inject the ghost point into _points index 1 (2nd entry), so if we then tool.addPoint, then the constrained point
 				// would be actually index 2 (3rd entry) in _points which is not what we want.
-				console.log('finalLogicalPoint before if statement', JSON.parse(JSON.stringify(finalLogicalPoint)))
 				if (finalLogicalPoint) {
 					tool.addPoint(finalLogicalPoint);
 				} else {
@@ -1166,7 +1175,8 @@ export class InteractionManager<HorzScaleItem> {
             if (rawScreenPoint && toolBeingCreated.pointsCount === 1) {
                 // Single point tools are immediately completed on the first click.
                 // We use setLastPoint to visualize the *final* tool location pre-click.
-                const logicalPoint = this.screenPointToLineToolPoint(rawScreenPoint);
+                // params.point from crosshair events is pane-relative.
+                const logicalPoint = this.screenPointToLineToolPoint(rawScreenPoint, true);
                 if (logicalPoint) {
                     toolBeingCreated.setLastPoint(logicalPoint);
                     this._plugin.requestUpdate();
@@ -1225,7 +1235,8 @@ export class InteractionManager<HorzScaleItem> {
 			}
 
 			if (finalScreenPoint) {
-				const logicalPoint = this.screenPointToLineToolPoint(finalScreenPoint);
+				// Crosshair event points are pane-relative
+				const logicalPoint = this.screenPointToLineToolPoint(finalScreenPoint, true);
 
 				if (logicalPoint) {
 					// We use setLastPoint for ghosting until the final point is committed.
@@ -1273,11 +1284,16 @@ export class InteractionManager<HorzScaleItem> {
 			if(!tool.options().visible) {
 				continue;
 			}
- 
-			const hitResult = tool._internalHitTest(point.x, point.y);
+
+			// Adjust Y to be pane-relative for the tool's pane, since the tool's
+			// rendered coordinates are pane-relative but point.y is chart-relative.
+			const toolPaneOffset = this._getPaneYOffsetForTool(tool);
+			const adjustedY = point.y - toolPaneOffset;
+
+			const hitResult = tool._internalHitTest(point.x, adjustedY as Coordinate);
 
 			if (hitResult) {
-				return { 
+				return {
 					tool: tool,
 					// The data() method gives us the payload, which is { pointIndex, cursorType }
 					pointIndex: hitResult.data()?.pointIndex ?? null,
@@ -1304,6 +1320,46 @@ export class InteractionManager<HorzScaleItem> {
 			this._selectedTool = null;
 			this._plugin.requestUpdate();
 		}
+	}
+
+	/**
+	 * Returns the Y offset (in CSS pixels) of the pane that contains `this._series`,
+	 * measured from the top of the chart element.
+	 * For pane 0 this returns 0, so existing single-pane behaviour is unaffected.
+	 */
+	private _getActivePaneYOffset(): number {
+		try {
+			const chartRect = this._chart.chartElement().getBoundingClientRect();
+			const panes = (this._chart as any).panes?.();
+			if (!panes) return 0;
+			for (const pane of panes) {
+				const series = pane.getSeries?.();
+				if (series && series.indexOf(this._series) !== -1) {
+					const paneEl = pane.getHTMLElement?.();
+					if (paneEl) {
+						return paneEl.getBoundingClientRect().top - chartRect.top;
+					}
+					break;
+				}
+			}
+		} catch { /* fallback */ }
+		return 0;
+	}
+
+	/**
+	 * Returns the Y offset of the pane a specific tool is rendered in.
+	 * Used by _hitTest to convert chart-relative Y to pane-relative Y.
+	 */
+	private _getPaneYOffsetForTool(tool: BaseLineTool<HorzScaleItem>): number {
+		try {
+			const chartRect = this._chart.chartElement().getBoundingClientRect();
+			const pane = tool.getPane();
+			const paneEl = pane?.getHTMLElement?.();
+			if (paneEl) {
+				return paneEl.getBoundingClientRect().top - chartRect.top;
+			}
+		} catch { /* fallback — tool might not be attached yet */ }
+		return 0;
 	}
 
 	/**

--- a/src/model/base-line-tool.ts
+++ b/src/model/base-line-tool.ts
@@ -370,7 +370,14 @@ export abstract class BaseLineTool<HorzScaleItem> extends PriceDataSource<HorzSc
 			console.warn(`[BaseLineTool] Tool ${this.id()} attached to a series not found in any pane. This primitive relies on IPaneApi access.`);
 		}
 
-		console.log(`Tool ${this.toolType} with ID ${this.id()} attached to series.`);
+		// Propagate the new series to all pane views so they use the correct
+		// price scale for coordinate conversions (critical for multi-pane).
+		for (const pv of this._paneViews) {
+			if (typeof (pv as any).updateSeries === 'function') {
+				(pv as any).updateSeries(param.series);
+			}
+		}
+
 	}
 
 	/**
@@ -432,7 +439,6 @@ export abstract class BaseLineTool<HorzScaleItem> extends PriceDataSource<HorzSc
 	 * @returns void
 	 */
 	public detached(): void {
-		console.log(`[BaseLineTool] Tool ${this.id()} detached from series.`);
 
 		// Nullify references to LWCharts APIs to prevent memory leaks / stale closures.
 		// This is important because chart/series APIs might hold references back to the primitive.
@@ -1048,10 +1054,10 @@ export abstract class BaseLineTool<HorzScaleItem> extends PriceDataSource<HorzSc
 
 		// Clear references to views and internal data
 		this._paneViews.forEach(paneView => {
-			const renderer = paneView.renderer();
-			if (renderer && renderer.clear) { // Check if the renderer has a clear method
-				renderer.clear();
-			}
+			try {
+				const renderer = paneView.renderer();
+				if (renderer && renderer.clear) { renderer.clear(); }
+			} catch { /* chart/series may already be detached */ }
 		});
 		(this._paneViews as any) = []; // Breaks references to renderers and views
 		(this._points as any) = [];

--- a/src/rendering/composite-renderer.ts
+++ b/src/rendering/composite-renderer.ts
@@ -70,7 +70,11 @@ export class CompositeRenderer<HorzScaleItem> implements IPaneRenderer {
 			return;
 		}
 		this._renderers.forEach((renderer: IPaneRenderer) => {
-			renderer.draw(target);
+			try {
+				renderer.draw(target);
+			} catch (e) {
+				console.warn('[CompositeRenderer] Error in renderer.draw:', e);
+			}
 		});
 	}
 

--- a/src/views/line-tool-pane-view.ts
+++ b/src/views/line-tool-pane-view.ts
@@ -44,7 +44,7 @@ export abstract class LineToolPaneView<HorzScaleItem> implements IUpdatablePaneV
      * Used for price-to-coordinate conversions.
      * @protected
      */
-    protected readonly _series: ISeriesApi<SeriesType, HorzScaleItem>;
+    protected _series: ISeriesApi<SeriesType, HorzScaleItem>;
 	
 
     /**
@@ -110,11 +110,20 @@ export abstract class LineToolPaneView<HorzScaleItem> implements IUpdatablePaneV
     }
 
     /**
+     * Updates the series reference used for price-to-coordinate conversions.
+     * Called when the tool is reattached to a different series (e.g. multi-pane).
+     */
+    public updateSeries(series: ISeriesApi<SeriesType, HorzScaleItem>): void {
+        this._series = series;
+        this._invalidated = true;
+    }
+
+    /**
      * Signals that the view's data or options have changed.
-     * 
+     *
      * Sets the `_invalidated` flag to `true`, forcing a recalculation of geometry
      * and render data during the next paint cycle.
-     * 
+     *
      * @param updateType - The type of update (e.g., 'data', 'options').
      */
     public update(updateType?: 'data' | 'other' | 'options'): void {
@@ -141,7 +150,12 @@ export abstract class LineToolPaneView<HorzScaleItem> implements IUpdatablePaneV
                 return null;
             }
 
-            this._updateImpl(height, width);
+            try {
+                this._updateImpl(height, width);
+            } catch (e) {
+                console.warn('[LineToolPaneView] Error in _updateImpl:', e);
+                (this._renderer as CompositeRenderer<HorzScaleItem>).clear();
+            }
             this._invalidated = false;
         }
         return this._renderer;


### PR DESCRIPTION
Adds setLocked/isLocked to prevent interaction during bulk drawing restoration, fixes Y-coordinate hit-testing across multiple panes, allows series replacement on existing drawings (for chart type switches), and wraps draw()/destroy() in try-catch so one broken drawing can't crash the chart.