### PR TITLE
feat(api): Implement `subscribeLineToolsSelect` API for tool selection events

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ Fires when a line tool is modified, moved, or finished being created. This is th
 #### `subscribeLineToolsDoubleClick(handler)`
 Fires when a user double-clicks an existing tool. Often used to open a custom "Properties" or "Settings" modal.
 
+#### `subscribeLineToolsSelect(handler)`
+Fires when a user single-clicks to select a line tool, or clicks empty space to deselect. The handler receives the selected tool's data, or `null` if all tools are deselected.
+
 ## Manual Crosshair Control
 
 #### `setCrossHairXY(x, y, visible)`

--- a/src/api/public-api.ts
+++ b/src/api/public-api.ts
@@ -66,6 +66,15 @@ export interface LineToolExport<T extends LineToolType> {
 // #region Event Structures
 
 /**
+ * Defines the structured data payload passed to listeners when a line tool is selected or deselected.
+ *
+ * @property selectedLineTool - The full {@link LineToolExport} data of the tool that was selected, or `null` if all tools were deselected.
+ */
+export interface LineToolsSelectEventParams {
+	selectedLineTool: LineToolExport<LineToolType> | null;
+}
+
+/**
  * Defines the structured data payload passed to listeners when a double-click event occurs on a line tool.
  *
  * This structure is kept identical to the original V3.8 event output for drop-in compatibility.
@@ -91,6 +100,13 @@ export interface LineToolsAfterEditEventParams {
 	selectedLineTool: LineToolExport<LineToolType>;
 	stage: 'lineToolEdited' | 'pathFinished' | 'lineToolFinished';
 }
+
+/**
+ * The function signature required for handlers subscribing to the select event.
+ *
+ * @param param - The event data containing the details of the selected tool, or null if deselected.
+ */
+export type LineToolsSelectEventHandler = (param: LineToolsSelectEventParams) => void;
 
 /**
  * The function signature required for handlers subscribing to the double-click event.
@@ -297,6 +313,22 @@ export interface ILineToolsApi {
 	 * @returns void
 	 */
 	unsubscribeLineToolsAfterEdit(handler: LineToolsAfterEditEventHandler): void;
+	
+	/**
+	 * Subscribes a handler function to the event that fires when a line tool is selected or deselected.
+	 *
+	 * @param handler - The callback function to execute. It receives a {@link LineToolsSelectEventParams} object.
+	 * @returns void
+	 */
+	subscribeLineToolsSelect(handler: LineToolsSelectEventHandler): void;
+
+	/**
+	 * Unsubscribes a handler function from the select event.
+	 *
+	 * @param handler - The previously subscribed handler function.
+	 * @returns void
+	 */
+	unsubscribeLineToolsSelect(handler: LineToolsSelectEventHandler): void;
 	
 	/**
 	 * Programmatically positions the chart's crosshair at a specific screen pixel coordinate.

--- a/src/core-plugin.ts
+++ b/src/core-plugin.ts
@@ -8,7 +8,9 @@ import {
 	LineToolsAfterEditEventHandler,
 	LineToolsDoubleClickEventHandler,
 	LineToolsDoubleClickEventParams,
-	LineToolsAfterEditEventParams
+	LineToolsAfterEditEventParams,
+	LineToolsSelectEventHandler,
+	LineToolsSelectEventParams
 } from './api/public-api';
 import { Delegate } from './utils/helpers';
 import { LineToolPartialOptionsMap, LineToolType, IChartWidgetBase } from './types';
@@ -43,6 +45,7 @@ export class LineToolsCorePlugin<HorzScaleItem> implements ILineToolsApi {
 	// Delegates for broadcasting V3.8-compatible events
 	private readonly _doubleClickDelegate = new Delegate<LineToolsDoubleClickEventParams>();
 	private readonly _afterEditDelegate = new Delegate<LineToolsAfterEditEventParams>();
+	private readonly _selectDelegate = new Delegate<LineToolsSelectEventParams>();
 
 	// Throttled Stacking Update
 	private _stackingUpdateScheduled: boolean = false;
@@ -469,6 +472,28 @@ export class LineToolsCorePlugin<HorzScaleItem> implements ILineToolsApi {
 		this._afterEditDelegate.unsubscribe(handler);
 	}
 
+	/**
+	 * Subscribes a callback function to the "Select" event.
+	 *
+	 * This event fires whenever a line tool is selected or deselected.
+	 *
+	 * @param handler - The function to execute when the event fires. Receives {@link LineToolsSelectEventParams}.
+	 * @returns void
+	 */
+	public subscribeLineToolsSelect(handler: LineToolsSelectEventHandler): void {
+		this._selectDelegate.subscribe(handler);
+	}
+
+	/**
+	 * Unsubscribes a previously registered callback from the "Select" event.
+	 *
+	 * @param handler - The specific callback function that was passed to {@link subscribeLineToolsSelect}.
+	 * @returns void
+	 */
+	public unsubscribeLineToolsSelect(handler: LineToolsSelectEventHandler): void {
+		this._selectDelegate.unsubscribe(handler);
+	}
+
 
 
 	/**
@@ -545,6 +570,23 @@ export class LineToolsCorePlugin<HorzScaleItem> implements ILineToolsApi {
 			selectedLineTool: tool.getExportData(),
 		};
 		this._doubleClickDelegate.fire(eventParams);
+	}
+
+	/**
+	 * Broadcasts an event indicating that a line tool has been selected or deselected.
+	 *
+	 * This method is called internally by the {@link InteractionManager} when selection state changes.
+	 *
+	 * @internal
+	 * @param tool - The tool instance that was selected, or null if tools were deselected.
+	 * @returns void
+	 */
+	public fireSelectEvent(tool: BaseLineTool<HorzScaleItem> | null): void {
+		console.log(`[CorePlugin] Firing Select event for tool: ${tool ? tool.id() : 'none (deselected)'}`);
+		const eventParams: LineToolsSelectEventParams = {
+			selectedLineTool: tool ? tool.getExportData() : null,
+		};
+		this._selectDelegate.fire(eventParams);
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,8 @@ function createDummyPluginApi(): ILineToolsPlugin {
 		unsubscribeLineToolsDoubleClick: dummyFn,
 		subscribeLineToolsAfterEdit: dummyFn,
 		unsubscribeLineToolsAfterEdit: dummyFn,
+		subscribeLineToolsSelect: dummyFn,
+		unsubscribeLineToolsSelect: dummyFn,
 		setCrossHairXY: dummyFn,
 		clearCrossHair: dummyFn,
 	};

--- a/src/interaction/interaction-manager.ts
+++ b/src/interaction/interaction-manager.ts
@@ -234,6 +234,7 @@ export class InteractionManager<HorzScaleItem> {
 		}
 		if (this._selectedTool === tool) {
 			this._selectedTool = null;
+			this._plugin.fireSelectEvent(null);
 		}
 		if (this._hoveredTool === tool) {
 			this._hoveredTool = null;
@@ -279,6 +280,7 @@ export class InteractionManager<HorzScaleItem> {
 		this.deselectAllTools();
 		this._selectedTool = tool;
 		this._selectedTool.setSelected(true);
+		this._plugin.fireSelectEvent(this._selectedTool);
 
 		// --- NEW FIX: Call normalize() if implemented by the tool ---
 		const toolWithNormalize = tool as BaseLineTool<HorzScaleItem> & { normalize?: () => void };
@@ -346,6 +348,7 @@ export class InteractionManager<HorzScaleItem> {
 				this.deselectAllTools();
 				this._selectedTool = hitResult.tool;
 				this._selectedTool.setSelected(true);
+				this._plugin.fireSelectEvent(this._selectedTool);
 			}
 
 			this._draggedTool = hitResult.tool;
@@ -1067,6 +1070,7 @@ export class InteractionManager<HorzScaleItem> {
 			this.deselectAllTools();
 			this._selectedTool = clickedTool;
 			this._selectedTool.setSelected(true);
+			this._plugin.fireSelectEvent(this._selectedTool);
 		} else {
 			this.deselectAllTools();
 		}
@@ -1275,6 +1279,7 @@ export class InteractionManager<HorzScaleItem> {
 			//console.log('inside selectedTool')
 			this._selectedTool.setSelected(false);
 			this._selectedTool = null;
+			this._plugin.fireSelectEvent(null);
 			this._plugin.requestUpdate();
 		}
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -566,7 +566,7 @@ export interface LineToolPathOptions { line: Omit<LineOptions, 'cap' | 'extend' 
  * Specific options for the Fibonacci Retracement tool.
  * Configures the trend line, the retracement levels (coefficients/colors), and optional trading strategy displays.
  */
-export interface LineToolFibRetracementOptions { line: Omit<LineOptions, 'extend' | 'join' | 'color' | 'cap' | 'end'>; extend: ExtendOptions; levels: FibRetracementLevel[]; tradeStrategy: FibRetracementTradeStrategy; }
+export interface LineToolFibRetracementOptions { line: Omit<LineOptions, 'extend' | 'join' | 'color' | 'cap' | 'end'>; extend: ExtendOptions; levels: FibRetracementLevel[]; tradeStrategy: FibRetracementTradeStrategy; fixedWidth?: number; }
 
 /**
  * Specific options for the Parallel Channel tool.


### PR DESCRIPTION
**Description:**
This PR introduces the `subscribeLineToolsSelect` API, allowing consumers to listen for single-click selection and deselection events on line tools. This fills the gap left by `subscribeLineToolsDoubleClick` and is essential for synchronizing external UI property panels with the chart's active selection state.

**Key Changes:**
- Defined `LineToolsSelectEventParams` in `public-api.ts` which returns the selected tool's export data or `null` upon deselection.
- Added `subscribeLineToolsSelect` and `unsubscribeLineToolsSelect` methods to `ILineToolsApi` and its implementing classes.
- Introduced `_selectDelegate` and `fireSelectEvent(tool)` in `LineToolsCorePlugin` for broadcasting.
- Integrated event triggers within `InteractionManager` (`_handleMouseDown`, `_handleStandaloneClick`, and `_finalizeToolCreation`) to fire upon tool selection.
- Ensured `fireSelectEvent(null)` is properly triggered within `deselectAllTools()` and `detachTool()` to accurately reflect when a tool is deselected or programmatically removed.
- Updated `README.md` to document the new API methods.